### PR TITLE
feat: Support multi agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ npx ai-agent-skills install frontend-design
 npx ai-agent-skills install frontend-design --agent cursor
 npx ai-agent-skills install frontend-design --agent codex
 npx ai-agent-skills install frontend-design --agent amp
+npx ai-agent-skills install frontend-design --agent codex,cursor
 
 # Install from any GitHub repo
 npx ai-agent-skills install anthropics/skills
@@ -131,6 +132,7 @@ npx ai-agent-skills browse
 npx ai-agent-skills list
 npx ai-agent-skills list --category development
 npx ai-agent-skills list --installed --agent cursor
+npx ai-agent-skills list --installed --agent cursor,codex
 
 # Install from catalog, GitHub, or local path
 npx ai-agent-skills install <name>                    # from catalog
@@ -138,6 +140,7 @@ npx ai-agent-skills install <owner/repo>              # from GitHub
 npx ai-agent-skills install <owner/repo/skill>        # specific skill from GitHub
 npx ai-agent-skills install ./path                    # from local path
 npx ai-agent-skills install <name> --agent cursor     # for specific agent
+npx ai-agent-skills install <name> --agent cursor,codex
 npx ai-agent-skills install <name> --dry-run          # preview only
 
 # Manage installed skills


### PR DESCRIPTION
## Summary
  - Allow comma-separated or repeated --agent flags
  - Apply install/update/uninstall/list across all specified agents
  - Update help text + README examples
 
## Type

- [ ] New skill
- [ ] Skill update/fix
- [ ] Documentation
- [x] Other

## Checklist

- [ ] SKILL.md has valid YAML frontmatter with `name` and `description`
- [ ] Skill name is lowercase with hyphens only
- [ ] Added entry to `skills.json`
- [x] Tested the skill works as expected

## Testing: 
```
❯ node cli.js install pdf --agent codex,cursor

Installed: pdf
Agents: codex, cursor
Location (codex): /Users/mahesh/.codex/skills/pdf
Location (cursor): /Users/mahesh/code/Ai-Agent-Skills/.cursor/skills/pdf
Size: 2.4 KB

The skill is now available in Codex.
The skill is installed in your project's .cursor/skills/ folder.
Cursor will automatically detect and use it.
```

