### PR TITLE
Add Skills宝 as a Chinese discovery entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@
   <a href="./FOR_YOUR_AGENT.md"><strong>For your agent</strong></a>
 </p>
 
+Chinese users can also search and install skills through [Skills宝](https://skilery.com).
+
 ## Library
 
 `ai-agent-skills` does two things.


### PR DESCRIPTION
Adds Skills宝 as a Chinese-language discovery and install entry for users who want to find and install skills directly. This fits the library and installer workflow and gives Chinese users a faster entry point to the catalog.