### PR TITLE
Add Bilig WorkPaper skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@
   <a href="https://github.com/MoizIbnYousaf/Ai-Agent-Skills"><img alt="GitHub stars" src="https://img.shields.io/github/stars/MoizIbnYousaf/Ai-Agent-Skills?style=for-the-badge&label=stars&labelColor=313244&color=89b4fa&logo=github&logoColor=cdd6f4" /></a>
   <a href="https://www.npmjs.com/package/ai-agent-skills"><img alt="npm version" src="https://img.shields.io/npm/v/ai-agent-skills?style=for-the-badge&label=version&labelColor=313244&color=b4befe&logo=npm&logoColor=cdd6f4" /></a>
   <a href="https://www.npmjs.com/package/ai-agent-skills"><img alt="npm total downloads" src="https://img.shields.io/npm/dt/ai-agent-skills?style=for-the-badge&label=downloads&labelColor=313244&color=f5e0dc&logo=npm&logoColor=cdd6f4" /></a>
-  <a href="https://github.com/MoizIbnYousaf/Ai-Agent-Skills#shelves"><img alt="Library structure" src="https://img.shields.io/badge/library-120%20skills%20%C2%B7%206%20shelves-cba6f7?style=for-the-badge&labelColor=313244&logo=bookstack&logoColor=cdd6f4" /></a>
+  <a href="https://github.com/MoizIbnYousaf/Ai-Agent-Skills#shelves"><img alt="Library structure" src="https://img.shields.io/badge/library-121%20skills%20%C2%B7%206%20shelves-cba6f7?style=for-the-badge&labelColor=313244&logo=bookstack&logoColor=cdd6f4" /></a>
 </p>
 
-<p align="center"><sub>17 house copies · 103 cataloged upstream</sub></p>
+<p align="center"><sub>17 house copies · 104 cataloged upstream</sub></p>
 <!-- GENERATED:library-stats:end -->
 
 <p align="center"><em>Picked, shelved, and maintained by hand.</em></p>
@@ -237,7 +237,7 @@ The shelves are the main structure.
 | Backend | 5 | Systems, data, security, and runtime operations. |
 | Mobile | 24 | Swift, SwiftUI, iOS, and Apple-platform development, with room for future React Native branches. |
 | Workflow | 11 | Files, docs, planning, release work, and research-to-output flows. |
-| Agent Engineering | 14 | MCP, skill-building, prompting discipline, and LLM application work. |
+| Agent Engineering | 15 | MCP, skill-building, prompting discipline, and LLM application work. |
 | Marketing | 56 | Brand, strategy, copy, distribution, creative, SEO, conversion, and growth work. |
 <!-- GENERATED:shelf-table:end -->
 
@@ -327,6 +327,7 @@ Current upstream mix:
 | `Erikote04/Swift-API-Design-Guidelines-Agent-Skill` | 1 |
 | `ivan-magda/swift-security-skill` | 1 |
 | `PasqualeVittoriosi/swift-accessibility-skill` | 1 |
+| `proompteng/bilig` | 1 |
 | `raphaelsalaja/userinterface-wiki` | 1 |
 | `shadcn-ui/ui` | 1 |
 | `twostraws/Swift-Concurrency-Agent-Skill` | 1 |

--- a/WORK_AREAS.md
+++ b/WORK_AREAS.md
@@ -60,14 +60,14 @@ House copies stay flat under `skills/<name>/`. The catalog holds the real struct
 
 ## Agent Engineering
 
-14 skills. MCP, skill-building, prompting discipline, and LLM application work.
+15 skills. MCP, skill-building, prompting discipline, and LLM application work.
 
 | Branch | Skills | Source |
 | --- | --- | --- |
 | Agent Behavior | `ask-questions-if-underspecified` | thsottiaux |
 | Agent Workflows | `browse-and-evaluate`, `update-installed-skills`, `review-a-skill` | MoizIbnYousaf |
 | LLM Apps | `llm-application-dev` | wshobson |
-| MCP | `mcp-builder` | anthropics |
+| MCP | `mcp-builder`, `bilig-workpaper` | anthropics, proompteng |
 | Prompting | `best-practices` | MoizIbnYousaf |
 | Provider Docs | `openai-docs` | openai |
 | Shared Libraries | `install-from-remote-library`, `curate-a-team-library`, `build-workspace-docs`, `audit-library-health`, `migrate-skills-between-libraries` | MoizIbnYousaf |

--- a/skills.json
+++ b/skills.json
@@ -1,7 +1,7 @@
 {
   "version": "4.3.2",
-  "updated": "2026-05-05",
-  "total": 120,
+  "updated": "2026-05-18",
+  "total": 121,
   "workAreas": [
     {
       "id": "frontend",
@@ -351,6 +351,38 @@
       "lastVerified": "2026-03-13",
       "vendored": false,
       "installSource": "anthropics/skills/skills/mcp-builder",
+      "tier": "upstream",
+      "distribution": "live",
+      "notes": "",
+      "labels": [],
+      "path": ""
+    },
+    {
+      "name": "bilig-workpaper",
+      "description": "Use Bilig WorkPaper when an agent needs spreadsheet-style formulas through Node.js services, files, terminal commands, or MCP tools instead of driving Excel or browser spreadsheet UIs.",
+      "category": "development",
+      "workArea": "agent-engineering",
+      "branch": "MCP",
+      "author": "proompteng",
+      "source": "proompteng/bilig",
+      "license": "MIT",
+      "tags": [
+        "spreadsheet",
+        "formulas",
+        "workpaper",
+        "mcp",
+        "typescript",
+        "node"
+      ],
+      "featured": false,
+      "verified": false,
+      "origin": "curated",
+      "trust": "listed",
+      "syncMode": "live",
+      "sourceUrl": "https://github.com/proompteng/bilig/tree/main/skills/bilig-workpaper",
+      "whyHere": "Adds a concrete WorkPaper runtime skill for agents that need spreadsheet-style formulas without driving Excel or browser spreadsheet UIs.",
+      "vendored": false,
+      "installSource": "proompteng/bilig/skills/bilig-workpaper",
       "tier": "upstream",
       "distribution": "live",
       "notes": "",


### PR DESCRIPTION
Adds `bilig-workpaper` as a cataloged upstream Agent Engineering / MCP skill.

Why it belongs:
- gives agents a concrete WorkPaper runtime for spreadsheet-style formulas without driving Excel or browser spreadsheet UIs
- fits beside `mcp-builder`, but covers the runtime/tooling side for formula-backed workbook state
- keeps upstream work upstream through `proompteng/bilig/skills/bilig-workpaper`

Validation:
- `node scripts/validate.js` passes
- `node cli.js info bilig-workpaper --format text` resolves the catalog entry and install command

Note: I also started `node test.js`, but the full suite is not usable in my local environment because several git-fixture tests hit the 1Password signing agent while creating temporary commits; earlier unrelated checks also report the existing marketing-manifest and release-doc mismatches.