### PR TITLE
Add Xquik skill catalog entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@
   <a href="https://github.com/MoizIbnYousaf/Ai-Agent-Skills"><img alt="GitHub stars" src="https://img.shields.io/github/stars/MoizIbnYousaf/Ai-Agent-Skills?style=for-the-badge&label=stars&labelColor=313244&color=89b4fa&logo=github&logoColor=cdd6f4" /></a>
   <a href="https://www.npmjs.com/package/ai-agent-skills"><img alt="npm version" src="https://img.shields.io/npm/v/ai-agent-skills?style=for-the-badge&label=version&labelColor=313244&color=b4befe&logo=npm&logoColor=cdd6f4" /></a>
   <a href="https://www.npmjs.com/package/ai-agent-skills"><img alt="npm total downloads" src="https://img.shields.io/npm/dt/ai-agent-skills?style=for-the-badge&label=downloads&labelColor=313244&color=f5e0dc&logo=npm&logoColor=cdd6f4" /></a>
-  <a href="https://github.com/MoizIbnYousaf/Ai-Agent-Skills#shelves"><img alt="Library structure" src="https://img.shields.io/badge/library-120%20skills%20%C2%B7%206%20shelves-cba6f7?style=for-the-badge&labelColor=313244&logo=bookstack&logoColor=cdd6f4" /></a>
+  <a href="https://github.com/MoizIbnYousaf/Ai-Agent-Skills#shelves"><img alt="Library structure" src="https://img.shields.io/badge/library-121%20skills%20%C2%B7%206%20shelves-cba6f7?style=for-the-badge&labelColor=313244&logo=bookstack&logoColor=cdd6f4" /></a>
 </p>
 
-<p align="center"><sub>17 house copies · 103 cataloged upstream</sub></p>
+<p align="center"><sub>17 house copies · 104 cataloged upstream</sub></p>
 <!-- GENERATED:library-stats:end -->
 
 <p align="center"><em>Picked, shelved, and maintained by hand.</em></p>
@@ -237,7 +237,7 @@ The shelves are the main structure.
 | Backend | 5 | Systems, data, security, and runtime operations. |
 | Mobile | 24 | Swift, SwiftUI, iOS, and Apple-platform development, with room for future React Native branches. |
 | Workflow | 11 | Files, docs, planning, release work, and research-to-output flows. |
-| Agent Engineering | 14 | MCP, skill-building, prompting discipline, and LLM application work. |
+| Agent Engineering | 15 | MCP, skill-building, prompting discipline, and LLM application work. |
 | Marketing | 56 | Brand, strategy, copy, distribution, creative, SEO, conversion, and growth work. |
 <!-- GENERATED:shelf-table:end -->
 
@@ -334,6 +334,7 @@ Current upstream mix:
 | `twostraws/SwiftData-Agent-Skill` | 1 |
 | `twostraws/SwiftUI-Agent-Skill` | 1 |
 | `vanab/swiftdata-agent-skill` | 1 |
+| `Xquik-dev/x-twitter-scraper` | 1 |
 <!-- GENERATED:source-table:end -->
 
 The two biggest upstream publishers in this library are Anthropic and OpenAI.

--- a/WORK_AREAS.md
+++ b/WORK_AREAS.md
@@ -60,7 +60,7 @@ House copies stay flat under `skills/<name>/`. The catalog holds the real struct
 
 ## Agent Engineering
 
-14 skills. MCP, skill-building, prompting discipline, and LLM application work.
+15 skills. MCP, skill-building, prompting discipline, and LLM application work.
 
 | Branch | Skills | Source |
 | --- | --- | --- |
@@ -69,7 +69,7 @@ House copies stay flat under `skills/<name>/`. The catalog holds the real struct
 | LLM Apps | `llm-application-dev` | wshobson |
 | MCP | `mcp-builder` | anthropics |
 | Prompting | `best-practices` | MoizIbnYousaf |
-| Provider Docs | `openai-docs` | openai |
+| Provider Docs | `openai-docs`, `x-twitter-scraper` | openai, Xquik-dev |
 | Shared Libraries | `install-from-remote-library`, `curate-a-team-library`, `build-workspace-docs`, `audit-library-health`, `migrate-skills-between-libraries` | MoizIbnYousaf |
 | Skill Authoring | `skill-creator` | anthropics |
 

--- a/skills.json
+++ b/skills.json
@@ -1,7 +1,7 @@
 {
   "version": "4.3.2",
-  "updated": "2026-05-05",
-  "total": 120,
+  "updated": "2026-06-29T00:00:00Z",
+  "total": 121,
   "workAreas": [
     {
       "id": "frontend",
@@ -3943,6 +3943,38 @@
       "distribution": "live",
       "notes": "",
       "labels": []
+    },
+    {
+      "name": "x-twitter-scraper",
+      "description": "Use when the user needs X (Twitter) data through Xquik: REST API integration, MCP setup, SDK setup, tweet search, user lookup, timeline reads, follower export, media download, monitoring, webhooks, bulk extraction, giveaway draws, or confirmation-gated publishing workflows. Read-only by default, API-key only, no X login material, and every write, private read, monitor, webhook, or metered bulk job requires explicit approval.",
+      "category": "development",
+      "workArea": "agent-engineering",
+      "branch": "Provider Docs",
+      "author": "Xquik-dev",
+      "source": "Xquik-dev/x-twitter-scraper",
+      "license": "MIT",
+      "tier": "upstream",
+      "distribution": "live",
+      "vendored": false,
+      "installSource": "https://github.com/Xquik-dev/x-twitter-scraper/tree/master/skills/x-twitter-scraper",
+      "tags": [
+        "x",
+        "social-media",
+        "api",
+        "mcp"
+      ],
+      "featured": false,
+      "verified": false,
+      "origin": "curated",
+      "trust": "listed",
+      "syncMode": "live",
+      "sourceUrl": "https://github.com/Xquik-dev/x-twitter-scraper/tree/master/skills/x-twitter-scraper",
+      "whyHere": "Adds a source-backed X data and automation skill for REST API, MCP, monitoring, webhook, and approved publishing workflows.",
+      "lastVerified": "",
+      "notes": "",
+      "labels": [],
+      "addedDate": "2026-06-29",
+      "lastCurated": "2026-06-29T00:00:00Z"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Add the Xquik `x-twitter-scraper` upstream skill to the Agent Engineering / Provider Docs shelf.
- Refresh generated README and WORK_AREAS counts and source table.

## Checks

- `node scripts/validate.js` passed with the existing `tiktok-slideshow` warning.
- `git diff --check` passed.
- `curl -I -L https://github.com/Xquik-dev/x-twitter-scraper/tree/master/skills/x-twitter-scraper` returned 200.
- `npm test` has 3 baseline failures unrelated to this catalog entry:
  - `mktg manifest-backed skills are cataloged on the marketing shelf` expects 53 marketing skills, while `HEAD` has 56.
  - `latest release docs stay aligned with the current package version` expects release notes for 4.3.2.
  - `README keeps the launch timeline and universal installer context` is the same 4.3.2 release-note expectation.
